### PR TITLE
Create municipalities.js

### DIFF
--- a/municipalities.js
+++ b/municipalities.js
@@ -9,36 +9,96 @@ var municipalities = {
         authority: "Polícia Municipal do Porto",
         email: "policiamunicipal@cm-porto.pt"
     },
+    Amadora : {
+        name: "Amadora",
+        authority: "Polícia Municipal da Amadora",
+        email: "policia.municipal@cm-amadora.pt"
+    },
     Aveiro : {
         name: "Aveiro",
         authority: "Polícia Municipal de Aveiro",
         email: "policia.municipal@cm-aveiro.pt"
-    },
-    Coimbra : {
-        name: "Coimbra",
-        authority: "Polícia Municipal de Coimbra",
-        email: "policia.municipal@cm-coimbra.pt"
-    },
-    Oeiras : {
-        name: "Oeiras",
-        authority: "Polícia Municipal de Oeiras",
-        email: "spm@cm-oeiras.pt"
     },
     Braga : {
         name: "Braga",
         authority: "Polícia Municipal de Braga",
         email: "policia.municipal@cm-braga.pt"
     },
+    CabeceirasBasto : {
+        name: "Cabeceiras de Basto",
+        authority: "Polícia Municipal de Cabeceiras de Basto",
+        email: "policiamunicipal@cabeceirasdebasto.pt"
+    },
     Cascais : {
         name: "Cascais",
         authority: "Polícia Municipal de Cascais",
         email: "policia.municipal@cm-cascais.pt"
     },
+    Coimbra : {
+        name: "Coimbra",
+        authority: "Polícia Municipal de Coimbra",
+        email: "policia.municipal@cm-coimbra.pt"
+    },
+    Gondomar : {
+        name: "Gondomar",
+        authority: "Polícia Municipal de Gondomar",
+        email: "pmunicipal@cm-gondomar.pt"
+    },
+    Guimaraes : {
+        name: "Guimarães",
+        authority: "Polícia Municipal de Guimarães",
+        email: "policia.municipal@cm-guimaraes.pt"
+    },
+    Mafra : {
+        name: "Mafra",
+        authority: "Polícia Municipal de Mafra",
+        email: "policiamunicipal@cm-mafra.pt"
+    },
+    Maia : {
+        name: "Maia",
+        authority: "Polícia Municipal de Maia",
+        email: "pm@cm-maia.pt"
+    },
+    Loures : {
+        name: "Loures",
+        authority: "Polícia Municipal de Loures",
+        email: "policia_municipal@cm-loures.pt"
+    },
+    Oeiras : {
+        name: "Oeiras",
+        authority: "Polícia Municipal de Oeiras",
+        email: "spm@cm-oeiras.pt"
+    },
+    PontaDelgada : {
+        name: "Ponta Delgada",
+        authority: "Polícia Municipal de Ponta Delgada",
+        email: "policiamunicipal@mpdelgada.pt"
+    },
+    PovoaVarzim : {
+        name: "Póvoa de Varzim",
+        authority: "Polícia Municipal de Póvoa de Varzim",
+        email: "policiamunicipal@cm-pvarzim.pt"
+    },
+    SantoTirso : {
+        name: "Santo Tirso",
+        authority: "Polícia Municipal de Santo Tirso",
+        email: "pm@cm-stirso.pt"
+    },
     Sintra : {
         name: "Sintra",
         authority: "Polícia Municipal de Sintra",
         email: "policiamunicipal@cm-sintra.pt"
-    }      
+    },
+    Trofa : {
+        name: "Trofa",
+        authority: "Polícia Municipal de Trofa",
+        email: "policia.municipal@mun-trofa.pt"
+    },
+    Viseu : {
+        name: "Viseu",
+        authority: "Polícia Municipal de Viseu",
+        email: "policia.municipal@cmviseu.pt"
+    }
 };
 
 


### PR DESCRIPTION
Acrescentados:
Amadora
Cabeceiras de Basto
Gondomar
Guimarães
Mafra
Maia
Loures
Ponta Delgada
Póvoa de Varzim
Santo Tirso
Trofa
Viseu

Ordenados alfabeticamente excepto Lisboa e Porto devido à sua maior utilização