### PR TITLE
Corrigir a utilização do termo "reportar"

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -41,7 +41,7 @@
 
         <li id="form_show">
           <div><i class="fas fa-paper-plane"></i></div>
-          <div><a>Reportar</a></div>
+          <div><a>Denunciar</a></div>
         </li>
 
         <li id="personal_data_show">


### PR DESCRIPTION
O termo "reportar" significa "referir-se a algo" e não "denunciar" ou "dar a conhecer" (nem tão pouco "responder a alguém" ou "estar sob o comando de alguém" quando se fala de hierarquias).

Como exemplo do uso correcto do termo, imaginemos um advogado a falar numa sessão num tribunal: "reportando-me aos factos do dia 10 de Outubro, concluo que o réu é inocente."

Um exemplo real, de um [Acórdão do Tribunal Central Administrativo Norte](http://www.dgsi.pt/jtcn.nsf/89d1c0288c2dd49c802575c8003279c7/11f23dd882287a7b80258089004e6586):
"O C.P.P.T. não fixa qualquer prazo de validade à informação prestada, é preciso notar que ela tem, no entanto, dois termos de referência. Por um lado, ela *reporta-se* aos factos enunciados pelo contribuinte; por outro, *reporta-se* ao enquadramento jurídico que deles fazem os serviços."

Referência: https://dicionario.priberam.org/reportar

Assim sendo, um possível termo mais correcto a usar neste caso será o que proponho: "denunciar" - até porque o título da própria aplicação refere as denúncias.