### PR TITLE
Adds size attribute to multiple select element

### DIFF
--- a/www/html-partials/mainForm.hbs
+++ b/www/html-partials/mainForm.hbs
@@ -119,7 +119,7 @@
           data-mobile="true"
           data-multiple-separator="; "
           data-none-selected-text="Nenhuma selecionada"
-          id="penalties" name="Tipo de Ocorrência" multiple>
+          id="penalties" name="Tipo de Ocorrência" multiple size="1">
         </select>
       </div>
     </div>


### PR DESCRIPTION
This fixes select not working correctly on Android 35.

> Use the attribute size="1" in the select element.
https://github.com/snapappointments/bootstrap-select/issues/2886

fixes #209, #214 