### PR TITLE
Removes invalid email vctesqsede@psp.pt

### DIFF
--- a/www/js/contacts.js
+++ b/www/js/contacts.js
@@ -5222,10 +5222,6 @@ app.contacts.PSP_Contacts = [
     'contacto': 'cpvcastelo@psp.pt'
   },
   {
-    'nome': 'Viana do Castelo - Esquadra',
-    'contacto': 'vctesqsede@psp.pt'
-  },
-  {
     'nome': 'Vila Franca de Xira - Divisão Policial',
     'contacto': 'vfxira.lisboa@psp.pt'
   },


### PR DESCRIPTION
There is no official information for this email. Use contact for 'Viana do Castelo - Comando Distrital' instead.

Sending email to this address results in error:
> Remote Server returned '550 5.1.10 RESOLVER.ADR.RecipientNotFound; Recipient not found by SMTP address lookup'

fixes #203 