### PR TITLE
Update Ribeira Brava email address

### DIFF
--- a/www/js/contacts.js
+++ b/www/js/contacts.js
@@ -5087,7 +5087,7 @@ app.contacts.PSP_Contacts = [
   },
   {
     'nome': 'Ribeira Brava - Esquadra',
-    'contacto': 'madesqrbrava@psp.pt'
+    'contacto': 'rbrava.madeira@psp.pt'
   },
   {
     'nome': 'Rio Tinto - Gondomar - Esquadra',


### PR DESCRIPTION
rbrava.madeira@psp.pt is the email address listed on https://www.psp.pt/Pages/onde-estamos.aspx?f=Brava

Fixes #200 