### PR TITLE
Update Vila do Conde email address

### DIFF
--- a/www/js/contacts.js
+++ b/www/js/contacts.js
@@ -162,7 +162,7 @@ app.contacts.PM_Contacts = [
   },
   {
     'nome': 'Vila do Conde',
-    'contacto': 'geral@viladoconde.pt'
+    'contacto': 'geral@cm-viladoconde.pt'
   },
   {
     'nome': 'Vila Nova de Famalicão',


### PR DESCRIPTION
SNPM (Sindicato Nacional das Polícias Municipais) lists the old email, but viladoconde.pt is not a registered domain.

https://snpm.pt/policia-municipal/municipios/

Fixes #205 