### PR TITLE
Clarify contact for GNR Lagoa Algarve

### DIFF
--- a/www/js/contacts.js
+++ b/www/js/contacts.js
@@ -3071,7 +3071,7 @@ app.contacts.GNR_Contacts = [
     'contacto': 'ct.ctb.didn.pldr@gnr.pt'
   },
   {
-    'nome': 'Posto Territorial de Lagoa',
+    'nome': 'Posto Territorial de Lagoa (Algarve)',
     'contacto': 'ct.far.dslv.plag@gnr.pt'
   },
   {


### PR DESCRIPTION
Not to be confused with Lagoa (Açores)

Fixes #177 