### PR TITLE
Update PSP contacts for Vila Franca de Xira

### DIFF
--- a/www/js/contacts.js
+++ b/www/js/contacts.js
@@ -5234,12 +5234,8 @@ app.contacts.PSP_Contacts = [
     'contacto': 'vfxira.lisboa@psp.pt'
   },
   {
-    'nome': 'Vila Franca de Xira - Esq.ª de Intervenção e Fiscalização Policial',
-    'contacto': 'vfxira.lisboa@psp.pt'
-  },
-  {
     'nome': 'Vila Franca de Xira - Esquadra de Trânsito',
-    'contacto': 'vfxira.lisboa@psp.pt'
+    'contacto': 'etrvfx.lisboa@psp.pt'
   },
   {
     'nome': 'Vila Nova de Famalicão - Esquadra',


### PR DESCRIPTION
Removing Esq.ª de Intervenção e Fiscalização Policial because could not find any official information about it and the email is a duplicate.

https://www.psp.pt/Pages/onde-estamos.aspx?f=Xira

Fixes #190 