### PR TITLE
Update node-version from v20 to v22

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-24.04]
-        node-version: [20]
+        node-version: [22]
         
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         platform: [macos-latest]
-        node-version: [20]
+        node-version: [22]
         
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
Support for v20 ended on 30 Apr 2026.
Support for v22 will end on 30 Apr 2027.

https://endoflife.date/nodejs